### PR TITLE
Bugfix manual adding CanvasEffectVariants track

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ function(
             console.log('VariantEffectPlugin plugin starting');
             browser.registerTrackType({
 				label: 'CanvasEffectVariants',
-                type: 'VariantEffectPlugin/View/Track/CanvasEffectVariant'
+                type: 'VariantEffectPlugin/View/Track/CanvasEffectVariants'
             });
         }
     });


### PR DESCRIPTION
When adding a VCF track manually with type CanvasEffectVariants the plugin could not be found. This pull request adds a small bugfix to fix this. 