### PR TITLE
Add support to VEP created annotated vcf file

### DIFF
--- a/js/View/Track/CanvasEffectVariants.js
+++ b/js/View/Track/CanvasEffectVariants.js
@@ -36,9 +36,12 @@ define([
                             // "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|SIFT"
                             // ;CSQ=T|missense_variant|MODERATE||TraesCS1A02G001800|Transcript|TraesCS1A02G001800.1|protein_coding|1/2||||192|56|19|A/V|gCc/gTc|||1||||tolerated_low_confidence(0.29)
                             // get the sift score
-                            let regExp = /\(([^)]+)\)/; // get the string in parentheses
-                            let sift = regExp.exec(dataSplit[dataSplit.length - 1])[1];
-                            if (sift < 0.05) {return "#d30085"}
+                            // let regExp = /\(([^)]+)\)/; // get the string in parentheses
+                            // let sift = regExp.exec(dataSplit[dataSplit.length - 1])[1];
+                            // if (sift < 0.05) {return "#d30085"}
+                            let sift = dataSplit[dataSplit.length - 1];
+                            if (sift.includes("deleterious")) {return "#ff9a00"}
+                            
                         }
                         return 'purple';
                     } else if (eff_type === "synonymous_variant") {

--- a/js/View/Track/CanvasEffectVariants.js
+++ b/js/View/Track/CanvasEffectVariants.js
@@ -18,37 +18,18 @@ define([
             var value = feature.get('ANN')||feature.get('CSQ');
             if (typeof value !== 'undefined') {
                 var data = value.values;
-                for (var i = 0, len = data.length; i < len; i++) {
-                    counter = i + 1;
-                    /* console.log(value[i]); */
-                    var dataSplit = data[i].split("|");
-                    var eff_type = dataSplit[1];
-                    if (eff_type === "stop_gained") {
-                        return '#FF0000';
-                    } else if (eff_type.indexOf("splice_donor_variant") !== -1) {
-                        return '#FF0000';
-                    } else if (eff_type.indexOf("splice_acceptor_variant") !== -1) {
-                        return '#FF0000';
-                    } else if (eff_type.indexOf("frameshift_variant") !== -1) {
-                        return '#FF0000';
-                    } else if (eff_type === "missense_variant") {
-                        if (dataSplit.length > 16){ // default CSQ tag from VEP
-                            // "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|SIFT"
-                            // ;CSQ=T|missense_variant|MODERATE||TraesCS1A02G001800|Transcript|TraesCS1A02G001800.1|protein_coding|1/2||||192|56|19|A/V|gCc/gTc|||1||||tolerated_low_confidence(0.29)
-                            // get the sift score
-                            // let regExp = /\(([^)]+)\)/; // get the string in parentheses
-                            // let sift = regExp.exec(dataSplit[dataSplit.length - 1])[1];
-                            // if (sift < 0.05) {return "#d30085"}
-                            let sift = dataSplit[dataSplit.length - 1];
-                            if (sift.includes("deleterious")) {return "#ff9a00"}
-                            
-                        }
-                        return 'purple';
-                    } else if (eff_type === "synonymous_variant") {
-                        return '#00FF2F';
-                    }
+                let all_ann = data.join(',');
+                if (/stop_gained|splice_donor_variant|splice_acceptor_variant|frameshift_variant/.test(all_ann)) {
+                    return '#FF0000'; // red color
+                } else if (all_ann.includes("deleterious")){
+                    return "#ff9a00"; // orange for deleterious missense_variant if using VEP annotated vcf with SIFT score
+                } else if (all_ann.includes("missense_variant")){
+                    return 'purple';
+                } else if (all_ann.includes("synonymous_variant")){
+                    return '#00FF2F'; // green for synonymous variant
+                } else {
+                    return 'blue';
                 }
-                return 'blue'
             } else {
                 return 'blue'
             }

--- a/js/View/Track/CanvasEffectVariants.js
+++ b/js/View/Track/CanvasEffectVariants.js
@@ -15,7 +15,7 @@ define([
     ) {
         var variantColorCoding = function(feature) {
             /* console.log(feature); */
-            var value = feature.get('ANN');
+            var value = feature.get('ANN')||feature.get('CSQ');
             if (typeof value !== 'undefined') {
                 var data = value.values;
                 for (var i = 0, len = data.length; i < len; i++) {
@@ -32,6 +32,14 @@ define([
                     } else if (eff_type.indexOf("frameshift_variant") !== -1) {
                         return '#FF0000';
                     } else if (eff_type === "missense_variant") {
+                        if (dataSplit.length > 16){ // default CSQ tag from VEP
+                            // "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|SIFT"
+                            // ;CSQ=T|missense_variant|MODERATE||TraesCS1A02G001800|Transcript|TraesCS1A02G001800.1|protein_coding|1/2||||192|56|19|A/V|gCc/gTc|||1||||tolerated_low_confidence(0.29)
+                            // get the sift score
+                            let regExp = /\(([^)]+)\)/; // get the string in parentheses
+                            let sift = regExp.exec(dataSplit[dataSplit.length - 1])[1];
+                            if (sift < 0.05) {return "#d30085"}
+                        }
                         return 'purple';
                     } else if (eff_type === "synonymous_variant") {
                         return '#00FF2F';

--- a/js/View/Track/_VariantDetailMixin.js
+++ b/js/View/Track/_VariantDetailMixin.js
@@ -60,7 +60,7 @@ define([
                         annText += "<br>Amino acid change = " + aa_change;
                     }
                     if (sift != "") {
-                        annText += "<br>SIFT score = " + aa_change;
+                        annText += "<br>SIFT score = " + sift;
                     }
                     annText += "<br>";
 

--- a/js/View/Track/_VariantDetailMixin.js
+++ b/js/View/Track/_VariantDetailMixin.js
@@ -59,6 +59,9 @@ define([
                     if (aa_change != "") {
                         annText += "<br>Amino acid change = " + aa_change;
                     }
+                    if (sift != "") {
+                        annText += "<br>SIFT score = " + aa_change;
+                    }
                     annText += "<br>";
 
                 }

--- a/js/View/Track/_VariantDetailMixin.js
+++ b/js/View/Track/_VariantDetailMixin.js
@@ -34,7 +34,7 @@ define([
                     }), f
                 );
                 fmt('Length', Util.addCommas(f.get('end') - f.get('start')) + ' bp', f);
-                var ann = (f.get('ANN')||{}).values;
+                var ann = (f.get('ANN')||f.get('CSQ')||{}).values;
                 var annText = "";
                 for (var i = 0, len = ann.length; i < len; i++) {
                     counter = i + 1;
@@ -43,7 +43,12 @@ define([
                     var eff_type = dataSplit[1];
                     var severity = dataSplit[2];
                     var transcript_name = dataSplit[6];
-                    var aa_change = dataSplit[10];
+                    var aa_change = dataSplit[10]; // this is from snpEff vcf
+                    var sift = ""; // SIFT score
+                    if (dataSplit.length > 16) {
+                        aa_change = dataSplit[15].replace('/', dataSplit[14]); // CSQ default from VEP
+                        sift = dataSplit[dataSplit.length - 1];
+                    }
                     annText += "<b>SnpEffect_" + counter + ":</b><br>Mutation Effect = " + eff_type;
                     if (transcript_name != "") {
                         annText += "<br>Transcript = " + transcript_name;


### PR DESCRIPTION
Hi Hans,

The annotated vcf file from VEP now has the "CSQ" tag instead of the "ANN" tag like the ones from snpEff software.
I and German tested in our Jbrowser and it seems to work.

Thanks,

Junli